### PR TITLE
Add xindy to apt-get install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Benedikt Lang <mail@blang.io>
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -q && apt-get install -qy \
-    texlive-full \
+    texlive-full xindy \
     python-pygments gnuplot \
     make git \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Xindy is used to build glossaries and is needed when automate latex project build.

I use your image with gitlab-ci but it failed to build glossary for my project using xindy because it wasn't installed.